### PR TITLE
Handle Unifonic 201 response code as success for send_message method

### DIFF
--- a/lib/unifonic_sms.rb
+++ b/lib/unifonic_sms.rb
@@ -114,7 +114,7 @@ module UnifonicSms
       response = http.post(path, body, headers)
       response_body = JSON.parse(response.body)
 
-      if response.code.to_i == 200 && !response_body["data"].nil? 
+      if (response.code.to_i == 200 || response.code.to_i == 201) && !response_body["data"].nil? 
         return { message_id: response_body["data"]["MessageID"], 
                  status: response_body["data"]["Status"], 
                  number_of_units: response_body["data"]["NumberOfUnits"],


### PR DESCRIPTION
Hi,

Unifonic API returns 201 when new SMS message was created and enqueued for sending. Current implementation accepts only 200 status code as success. In their API is not mentioned for this endpoint but they describe it in general (https://unifonic.docs.apiary.io/#reference/http-status) that they can return 200 or 201 for sucessful POST requests.